### PR TITLE
Fixed `The stream is currently in use by a previous operation on the stream` error on Dispose.

### DIFF
--- a/src/Serilog.Sinks.FastConsole/FastConsoleSink.cs
+++ b/src/Serilog.Sinks.FastConsole/FastConsoleSink.cs
@@ -31,8 +31,7 @@ public class FastConsoleSink : ILogEventSink, IDisposable
             ? Channel.CreateBounded<LogEvent?>(new BoundedChannelOptions(options.QueueLimit!.Value) { SingleReader = true, FullMode = _options.BlockWhenFull ? BoundedChannelFullMode.Wait : BoundedChannelFullMode.DropWrite })
             : Channel.CreateUnbounded<LogEvent?>(new UnboundedChannelOptions { SingleReader = true });
 
-        // Use Task.Run instead of Task.Factory.StartNew since it unwraps Task<Task> into the just Task.
-        _worker = Task.Run(WriteToConsoleStream, CancellationToken.None);
+        _worker = Task.Factory.StartNew(WriteToConsoleStream, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).Unwrap();
     }
 
     public void Emit(LogEvent logEvent)

--- a/src/Serilog.Sinks.FastConsole/FastConsoleSink.cs
+++ b/src/Serilog.Sinks.FastConsole/FastConsoleSink.cs
@@ -31,7 +31,8 @@ public class FastConsoleSink : ILogEventSink, IDisposable
             ? Channel.CreateBounded<LogEvent?>(new BoundedChannelOptions(options.QueueLimit!.Value) { SingleReader = true, FullMode = _options.BlockWhenFull ? BoundedChannelFullMode.Wait : BoundedChannelFullMode.DropWrite })
             : Channel.CreateUnbounded<LogEvent?>(new UnboundedChannelOptions { SingleReader = true });
 
-        _worker = Task.Factory.StartNew(WriteToConsoleStream, CancellationToken.None, TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+        // Use Task.Run instead of Task.Factory.StartNew since it unwraps Task<Task> into the just Task.
+        _worker = Task.Run(WriteToConsoleStream, CancellationToken.None);
     }
 
     public void Emit(LogEvent logEvent)


### PR DESCRIPTION
This MR fixes InvalidOperationException caused by disposing `StreamWriter` which is currently in use:
```
System.InvalidOperationException
  HResult=0x80131509
  Message=The stream is currently in use by a previous operation on the stream.
  Source=mscorlib
  StackTrace:
   at System.IO.StreamWriter.CheckAsyncTaskInProgress()
   at System.IO.StreamWriter.Dispose(Boolean disposing)
   at System.IO.TextWriter.Dispose()
   at Serilog.Sinks.FastConsole.FastConsoleSink.Dispose(Boolean disposing) in D:\Work\Utils\serilog-sinks-fastconsole\src\Serilog.Sinks.FastConsole\FastConsoleSink.cs:line 166
   at Serilog.Sinks.FastConsole.FastConsoleSink.Dispose() in D:\Work\Utils\serilog-sinks-fastconsole\src\Serilog.Sinks.FastConsole\FastConsoleSink.cs:line 149
   at Serilog.LoggerConfiguration.<>c__DisplayClass32_0.<CreateLogger>g__Dispose|1()
   at Logger.Program.Main(String[] args) in D:\Work\Utils\Logger\Logger\Program.cs:line 90

```

The reason of the error is that Task.Factory.StartNew executed with async method as argument returns `Task<Task>`  and `_worker.ConfigureAwait(false).GetAwaiter().GetResult()` doesn't wait for task to complete.
https://devblogs.microsoft.com/pfxteam/task-run-vs-task-factory-startnew/