### PR TITLE
Always output entire log messages (#11)

### DIFF
--- a/src/Serilog.Sinks.FastConsole/FastConsoleSink.cs
+++ b/src/Serilog.Sinks.FastConsole/FastConsoleSink.cs
@@ -12,7 +12,11 @@ namespace Serilog.Sinks.FastConsole;
 
 public class FastConsoleSink : ILogEventSink, IDisposable
 {
-    private static readonly StreamWriter _consoleWriter = new(Console.OpenStandardOutput(), Console.OutputEncoding, 4096, true);
+    private static readonly StreamWriter _consoleWriter =
+        new(Console.OpenStandardOutput(), Console.OutputEncoding, 4096, true)
+        {
+            AutoFlush = true
+        };
     private readonly StringWriter _bufferWriter = new();
     private readonly Channel<LogEvent?> _queue;
     private readonly Task _worker;


### PR DESCRIPTION
This PR ensures that log messages are printed to the console's stdout in their entirety by flushing the internal buffer of the `StreamWriter` after every write operation.


Resolves #11